### PR TITLE
🐛fix:replace google and jcenter to aliyun

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -36,5 +36,15 @@
       <option name="name" value="maven2" />
       <option name="url" value="https://maven.aliyun.com/repository/jcenter" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="BintrayJCenter" />
+      <option name="name" value="BintrayJCenter" />
+      <option name="url" value="https://jcenter.bintray.com/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="Google" />
+      <option name="name" value="Google" />
+      <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,14 @@ apply from: "config.gradle"
 buildscript {
     ext.kotlin_version = '1.3.72'
     repositories {
-        maven {
-            url 'https://maven.aliyun.com/repository/google'
-        }
-        maven {
-            url 'https://maven.aliyun.com/repository/jcenter'
-        }
+        google()
+        jcenter()
+//        maven {
+//            url 'https://maven.aliyun.com/repository/google'
+//        }
+//        maven {
+//            url 'https://maven.aliyun.com/repository/jcenter'
+//        }
         mavenCentral()
         maven { url "https://jitpack.io" }
     }
@@ -24,12 +26,14 @@ buildscript {
 
 allprojects {
     repositories {
-        maven {
-            url 'https://maven.aliyun.com/repository/google'
-        }
-        maven {
-            url 'https://maven.aliyun.com/repository/jcenter'
-        }
+        google()
+        jcenter()
+//        maven {
+//            url 'https://maven.aliyun.com/repository/google'
+//        }
+//        maven {
+//            url 'https://maven.aliyun.com/repository/jcenter'
+//        }
         mavenCentral()
         maven {
             url "https://jitpack.io"


### PR DESCRIPTION
修复travis编译从阿里云镜像仓库里面找不到dataBinding-4.0.1的问题，使用原版google仓库